### PR TITLE
feat: make workshops responsive

### DIFF
--- a/src/app/_components/workshops-section.tsx
+++ b/src/app/_components/workshops-section.tsx
@@ -70,9 +70,8 @@ export function WorkshopsSection() {
                   onClick={() => window.open(workshop.lumaUrl, "_blank")}
                 >
                   <iframe
+                    className="w-full h-[800px] md:h-[460px]"
                     src={`https://lu.ma/embed/event/${workshop.embedId}/simple`}
-                    width="100%"
-                    height="460"
                     frameBorder="0"
                     style={{
                       border: "1px solid rgba(191, 203, 218, 0.2)",


### PR DESCRIPTION
The workshop information is not being entirely displayed on mobile devices.  (the information is cropped as the height of the iframe is fixed for all devices)

This adds responsiveness by changing the height of the workshop iframe accordingly when on mobile or tablet. 